### PR TITLE
Streaming OTF2 data into traveler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__
+env
+run_dir
+jobdata-*
+input.tgz
+uapp-key
+uapp-key.pub


### PR DESCRIPTION
Streaming OTF2 data into traveler at least works now from the command line (make sure to `git pull` the latest version of traveler-integrated).

This is still incomplete from the Jupyter side of things—this process revealed a design flaw in how I wanted to serve traveler from the notebook that I'm still working on.