### PR TITLE
Minor tweaks to make debugging traveler less hellish inside docker

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+docker-compose.override.yml

--- a/remote_run.py
+++ b/remote_run.py
@@ -29,11 +29,16 @@ def mk_label(fname, real_args):
 
 
 
-def viz(job):
+def viz(job, printTravelerResponse=False):
     try:
       with open("run_dir/name.txt","r") as fd:
         fname = fd.read().strip()
-      response = visualizeRemoteInTraveler(job.jobid)
+      (mainR, otfR) = visualizeRemoteInTraveler(job.jobid)
+      if printTravelerResponse:
+          for chunk in mainR.iter_content():
+              print(chunk.decode(), end='')
+          for chunk in otfR.iter_content():
+              print(chunk.decode(), end='')
     except Exception as e:
       print("Could not visualize result, Traveler missing/unavailable:")
       print("exception:",e)


### PR DESCRIPTION
This PR does two little things:
- Adds a `docker/.gitignore` to protect against committing `docker-compose.override.yml` files
- Adds a `printTravelerResponse` option to `viz()` (off by default) to print the traveler response in Jupyter (some debugging information comes back in the response, that can't be included in `serve.log` or on the browser console)